### PR TITLE
Closes #14 Fix: Improve error granularity for missing environmental credentials

### DIFF
--- a/__tmp1/057_shortest_path_C.h
+++ b/__tmp1/057_shortest_path_C.h
@@ -1,0 +1,313 @@
+// bfs_shortest_path.c
+// Compile:  gcc -O2 -std=c11 -Wall -Wextra -o bfs bfs_shortest_path.c
+// Usage:
+//   ./bfs graph.txt
+//   ./bfs --from A --to E graph.txt
+//   ./bfs --directed graph.txt
+//   cat graph.txt | ./bfs -
+//
+// Input format (any mix of spaces, tabs, or commas as delimiters):
+//   A  B  F          # node A has neighbors B and F
+//   B  A  C
+//   ...
+//   # A E            # query lines start with '#': find shortest path A -> E
+//
+// Notes:
+//   • If there are no query lines, provide --from SRC --to DST on CLI.
+//   • Default is UNDIRECTED; pass --directed for directed edges.
+//   • Multiple query lines are supported; each prints one result.
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <ctype.h>
+
+/* ---------------------------- tiny dynamic vector ---------------------------- */
+
+typedef struct {
+    int   *data;
+    size_t len, cap;
+} VecI;
+
+static void veci_init(VecI *v) { v->data = NULL; v->len = v->cap = 0; }
+
+static void veci_push(VecI *v, int x) {
+    if (v->len == v->cap) {
+        size_t ncap = v->cap ? v->cap * 2 : 4;
+        int *nd = (int*)realloc(v->data, ncap * sizeof(int));
+        if (!nd) { perror("realloc"); exit(1); }
+        v->data = nd; v->cap = ncap;
+    }
+    v->data[v->len++] = x;
+}
+
+static void veci_free(VecI *v) { free(v->data); v->data = NULL; v->len = v->cap = 0; }
+
+typedef struct {
+    char *a, *b;
+} PairStr;
+
+typedef struct {
+    PairStr *data;
+    size_t len, cap;
+} VecPair;
+
+static void vecpair_init(VecPair *v) { v->data = NULL; v->len = v->cap = 0; }
+static void vecpair_push(VecPair *v, PairStr p) {
+    if (v->len == v->cap) {
+        size_t ncap = v->cap ? v->cap * 2 : 4;
+        PairStr *nd = (PairStr*)realloc(v->data, ncap * sizeof(PairStr));
+        if (!nd) { perror("realloc"); exit(1); }
+        v->data = nd; v->cap = ncap;
+    }
+    v->data[v->len++] = p;
+}
+static void vecpair_free(VecPair *v) {
+    for (size_t i = 0; i < v->len; ++i) { free(v->data[i].a); free(v->data[i].b); }
+    free(v->data); v->data = NULL; v->len = v->cap = 0;
+}
+
+/* ----------------------------- graph structure ------------------------------ */
+
+typedef struct {
+    char *name;
+    VecI adj;
+} Node;
+
+typedef struct {
+    Node  *nodes;
+    size_t len, cap;
+} Graph;
+
+static void graph_init(Graph *g) { g->nodes = NULL; g->len = g->cap = 0; }
+
+static int graph_find(const Graph *g, const char *name) {
+    for (size_t i = 0; i < g->len; ++i)
+        if (strcmp(g->nodes[i].name, name) == 0) return (int)i;
+    return -1;
+}
+
+static int graph_add_node(Graph *g, const char *name) {
+    if (g->len == g->cap) {
+        size_t ncap = g->cap ? g->cap * 2 : 8;
+        Node *nn = (Node*)realloc(g->nodes, ncap * sizeof(Node));
+        if (!nn) { perror("realloc"); exit(1); }
+        g->nodes = nn; g->cap = ncap;
+    }
+    g->nodes[g->len].name = strdup(name);
+    veci_init(&g->nodes[g->len].adj);
+    return (int)g->len++;
+}
+
+static int graph_get_or_add(Graph *g, const char *name) {
+    int idx = graph_find(g, name);
+    if (idx >= 0) return idx;
+    return graph_add_node(g, name);
+}
+
+static void graph_add_edge(Graph *g, int u, int v, bool directed) {
+    veci_push(&g->nodes[u].adj, v);
+    if (!directed) veci_push(&g->nodes[v].adj, u);
+}
+
+static void graph_free(Graph *g) {
+    for (size_t i = 0; i < g->len; ++i) {
+        free(g->nodes[i].name);
+        veci_free(&g->nodes[i].adj);
+    }
+    free(g->nodes); g->nodes = NULL; g->len = g->cap = 0;
+}
+
+/* ------------------------------- string utils ------------------------------- */
+
+static char *str_trim(char *s) {
+    while (isspace((unsigned char)*s)) s++;
+    if (*s == 0) return s;
+    char *end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) end--;
+    end[1] = '\0';
+    return s;
+}
+
+static bool is_stdin_path(const char *p) { return p && strcmp(p, "-") == 0; }
+
+/* tokenization: spaces, tabs, commas */
+static const char *DELIMS = " \t,";
+
+/* ---------------------------------- BFS ------------------------------------- */
+
+static int* bfs_parent(const Graph *g, int s, int t) {
+    size_t n = g->len;
+    int *parent = (int*)malloc(n * sizeof(int));
+    bool *seen   = (bool*)calloc(n, sizeof(bool));
+    int *queue   = (int*)malloc(n * sizeof(int));
+    if (!parent || !seen || !queue) { perror("malloc"); exit(1); }
+    for (size_t i = 0; i < n; ++i) parent[i] = -1;
+
+    size_t head = 0, tail = 0;
+    queue[tail++] = s; seen[s] = true;
+
+    while (head < tail) {
+        int u = queue[head++];
+        if (u == t) break;
+        const VecI *adj = &g->nodes[u].adj;
+        for (size_t i = 0; i < adj->len; ++i) {
+            int v = adj->data[i];
+            if (!seen[v]) {
+                seen[v] = true;
+                parent[v] = u;
+                queue[tail++] = v;
+                if ((size_t)v == (size_t)t) { head = tail; break; }
+            }
+        }
+    }
+    free(seen); free(queue);
+    return parent; /* caller frees */
+}
+
+static void print_path(const Graph *g, int *parent, int s, int t) {
+    if (s == t) { printf("PATH (0 edges): %s\n", g->nodes[s].name); return; }
+    if (parent[t] == -1) { printf("NO PATH: %s -> %s\n", g->nodes[s].name, g->nodes[t].name); return; }
+
+    /* reconstruct */
+    size_t cap = 16, len = 0;
+    int *stk = (int*)malloc(cap * sizeof(int));
+    for (int cur = t; cur != -1; cur = parent[cur]) {
+        if (len == cap) { cap *= 2; stk = (int*)realloc(stk, cap * sizeof(int)); }
+        stk[len++] = cur;
+        if (cur == s) break;
+    }
+    if (stk[len - 1] != s) { printf("NO PATH: %s -> %s\n", g->nodes[s].name, g->nodes[t].name); free(stk); return; }
+    printf("PATH (%zu edges): ", len - 1);
+    for (size_t i = len; i-- > 0;) {
+        printf("%s", g->nodes[stk[i]].name);
+        if (i) printf(" -> ");
+    }
+    printf("\n");
+    free(stk);
+}
+
+/* ------------------------------- CLI parsing -------------------------------- */
+
+typedef struct {
+    bool directed;
+    const char *input;
+    const char *from;
+    const char *to;
+} Args;
+
+static void usage_and_exit(const char *msg) {
+    if (msg) fprintf(stderr, "ERROR: %s\n", msg);
+    fprintf(stderr,
+        "Usage: bfs [--directed] [--from SRC --to DST] <input path or '-'>\n");
+    exit(msg ? 2 : 0);
+}
+
+static Args parse_args(int argc, char **argv) {
+    Args a = { .directed = false, .input = "-", .from = NULL, .to = NULL };
+    for (int i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--directed") == 0) {
+            a.directed = true;
+        } else if (strcmp(argv[i], "--from") == 0) {
+            if (++i >= argc) usage_and_exit("Missing value after --from");
+            a.from = argv[i];
+        } else if (strcmp(argv[i], "--to") == 0) {
+            if (++i >= argc) usage_and_exit("Missing value after --to");
+            a.to = argv[i];
+        } else if (argv[i][0] == '-') {
+            if (strcmp(argv[i], "-") == 0) {
+                a.input = "-";
+            } else {
+                usage_and_exit("Unknown flag");
+            }
+        } else {
+            a.input = argv[i];
+        }
+    }
+    return a;
+}
+
+/* --------------------------------- main ------------------------------------- */
+
+int main(int argc, char **argv) {
+    Args args = parse_args(argc, argv);
+
+    FILE *fp = NULL;
+    if (is_stdin_path(args.input)) {
+        fp = stdin;
+    } else {
+        fp = fopen(args.input, "r");
+        if (!fp) { perror("fopen"); return 2; }
+    }
+
+    Graph g; graph_init(&g);
+    VecPair queries; vecpair_init(&queries);
+
+    char *line = NULL; size_t cap = 0; ssize_t nread;
+    while ((nread = getline(&line, &cap, fp)) != -1) {
+        char *s = str_trim(line);
+        if (*s == '\0') continue;
+
+        if (*s == '#') {
+            /* query line: "# SRC DST" */
+            s++;
+            while (isspace((unsigned char)*s)) s++;
+            if (*s == '\0') continue;
+            char *tmp = strdup(s);
+            char *tok = strtok(tmp, DELIMS);
+            char *src = NULL, *dst = NULL;
+            if (tok) { src = strdup(tok); tok = strtok(NULL, DELIMS); }
+            if (tok) { dst = strdup(tok); }
+            if (src && dst) vecpair_push(&queries, (PairStr){src, dst});
+            else { free(src); free(dst); }
+            free(tmp);
+            continue;
+        }
+
+        /* edge line: "U V1 V2 ..." (or just "U" for isolated) */
+        char *tmp = strdup(s);
+        char *tok = strtok(tmp, DELIMS);
+        if (!tok) { free(tmp); continue; }
+        int u = graph_get_or_add(&g, tok);
+
+        char *vstr = NULL;
+        while ((vstr = strtok(NULL, DELIMS)) != NULL) {
+            if (*vstr == '\0') continue;
+            int v = graph_get_or_add(&g, vstr);
+            graph_add_edge(&g, u, v, args.directed);
+        }
+        free(tmp);
+    }
+    free(line);
+    if (fp != stdin) fclose(fp);
+
+    /* If no inline queries, require --from/--to */
+    if (queries.len == 0) {
+        if (!args.from || !args.to) {
+            usage_and_exit("No queries in input and --from/--to not provided");
+        }
+        vecpair_push(&queries, (PairStr){ strdup(args.from), strdup(args.to) });
+    }
+
+    /* Execute queries */
+    for (size_t i = 0; i < queries.len; ++i) {
+        PairStr q = queries.data[i];
+        int s = graph_find(&g, q.a);
+        int t = graph_find(&g, q.b);
+        if (s < 0 || t < 0) {
+            printf("NO PATH: %s -> %s (unknown node)\n", q.a, q.b);
+            continue;
+        }
+        int *parent = bfs_parent(&g, s, t);
+        print_path(&g, parent, s, t);
+        free(parent);
+    }
+
+    /* cleanup */
+    vecpair_free(&queries);
+    graph_free(&g);
+    return 0;
+}
+

--- a/__tmp1/WelshPowellTest.java
+++ b/__tmp1/WelshPowellTest.java
@@ -1,0 +1,134 @@
+package com.thealgorithms.datastructures.graphs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.thealgorithms.datastructures.graphs.WelshPowell.Graph;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class WelshPowellTest {
+
+    @Test
+    void testSimpleGraph() {
+        final var graph = WelshPowell.makeGraph(4, new int[][] {{0, 1}, {1, 2}, {2, 3}});
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertEquals(2, countDistinctColors(colors));
+    }
+
+    @Test
+    void testDisconnectedGraph() {
+        final var graph = WelshPowell.makeGraph(3, new int[][] {}); // No edges
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertEquals(1, countDistinctColors(colors));
+    }
+
+    @Test
+    void testCompleteGraph() {
+        final var graph = WelshPowell.makeGraph(3, new int[][] {{0, 1}, {1, 2}, {2, 0}});
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertEquals(3, countDistinctColors(colors));
+    }
+
+    @Test
+    void testComplexGraph() {
+        int[][] edges = {
+            {0, 7},
+            {0, 1},
+            {1, 3},
+            {2, 3},
+            {3, 8},
+            {3, 10},
+            {4, 10},
+            {4, 5},
+            {5, 6},
+            {6, 10},
+            {6, 7},
+            {7, 8},
+            {7, 9},
+            {7, 10},
+            {8, 9},
+            {9, 10},
+        };
+
+        final var graph = WelshPowell.makeGraph(11, edges); // 11 vertices from A (0) to K (10)
+        int[] colors = WelshPowell.findColoring(graph);
+
+        assertTrue(isColoringValid(graph, colors), "The coloring should be valid with no adjacent vertices sharing the same color.");
+        assertEquals(3, countDistinctColors(colors), "The chromatic number of the graph should be 3.");
+    }
+
+    @Test
+    void testNegativeVertices() {
+        assertThrows(IllegalArgumentException.class, () -> { WelshPowell.makeGraph(-1, new int[][] {}); }, "Number of vertices cannot be negative");
+    }
+
+    @Test
+    void testSelfLoop() {
+        assertThrows(IllegalArgumentException.class, () -> { WelshPowell.makeGraph(3, new int[][] {{0, 0}}); }, "Self-loops are not allowed");
+    }
+
+    @Test
+    void testInvalidVertex() {
+        assertThrows(IllegalArgumentException.class, () -> { WelshPowell.makeGraph(3, new int[][] {{0, 3}}); }, "Vertex out of bounds");
+        assertThrows(IllegalArgumentException.class, () -> { WelshPowell.makeGraph(3, new int[][] {{0, -1}}); }, "Vertex out of bounds");
+    }
+
+    @Test
+    void testInvalidEdgeArray() {
+        assertThrows(IllegalArgumentException.class, () -> { WelshPowell.makeGraph(3, new int[][] {{0}}); }, "Edge array must have exactly two elements");
+    }
+
+    @Test
+    void testWithPreColoredVertex() {
+        final var graph = WelshPowell.makeGraph(4, new int[][] {{0, 1}, {1, 2}, {2, 3}});
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertTrue(countDistinctColors(colors) >= 2);
+        for (int color : colors) {
+            assertTrue(color >= 0);
+        }
+    }
+
+    @Test
+    void testLargeGraph() {
+        int[][] edges = {{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4, 5}, {5, 0}, {6, 7}, {7, 8}, {8, 6}, {9, 10}, {10, 11}, {11, 9}, {12, 13}, {13, 14}, {14, 15}};
+
+        final var graph = WelshPowell.makeGraph(16, edges); // 16 vertices
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertEquals(3, countDistinctColors(colors)); // Expecting a maximum of 3 colors
+    }
+
+    @Test
+    void testStarGraph() {
+        int[][] edges = {{0, 1}, {0, 2}, {0, 3}, {0, 4}};
+
+        final var graph = WelshPowell.makeGraph(5, edges); // 5 vertices in a star formation
+        int[] colors = WelshPowell.findColoring(graph);
+        assertTrue(isColoringValid(graph, colors));
+        assertEquals(2, countDistinctColors(colors)); // Star graph can be colored with 2 colors
+    }
+
+    private boolean isColoringValid(Graph graph, int[] colors) {
+        if (Arrays.stream(colors).anyMatch(n -> n < 0)) {
+            return false;
+        }
+        for (int i = 0; i < graph.getNumVertices(); i++) {
+            for (int neighbor : graph.getAdjacencyList(i)) {
+                if (i != neighbor && colors[i] == colors[neighbor]) {
+                    return false; // Adjacent vertices have the same color
+                }
+            }
+        }
+        return true; // No adjacent vertices share the same color
+    }
+
+    private int countDistinctColors(int[] colors) {
+        return (int) Arrays.stream(colors).distinct().count();
+    }
+}

--- a/__tmp1/heaps_algorithm.py
+++ b/__tmp1/heaps_algorithm.py
@@ -1,0 +1,56 @@
+"""
+Heap's algorithm returns the list of all permutations possible from a list.
+It minimizes movement by generating each permutation from the previous one
+by swapping only two elements.
+More information:
+https://en.wikipedia.org/wiki/Heap%27s_algorithm.
+"""
+
+
+def heaps(arr: list) -> list:
+    """
+    Pure python implementation of the Heap's algorithm (recursive version),
+    returning all permutations of a list.
+    >>> heaps([])
+    [()]
+    >>> heaps([0])
+    [(0,)]
+    >>> heaps([-1, 1])
+    [(-1, 1), (1, -1)]
+    >>> heaps([1, 2, 3])
+    [(1, 2, 3), (2, 1, 3), (3, 1, 2), (1, 3, 2), (2, 3, 1), (3, 2, 1)]
+    >>> from itertools import permutations
+    >>> sorted(heaps([1,2,3])) == sorted(permutations([1,2,3]))
+    True
+    >>> all(sorted(heaps(x)) == sorted(permutations(x))
+    ...     for x in ([], [0], [-1, 1], [1, 2, 3]))
+    True
+    """
+
+    if len(arr) <= 1:
+        return [tuple(arr)]
+
+    res = []
+
+    def generate(k: int, arr: list):
+        if k == 1:
+            res.append(tuple(arr[:]))
+            return
+
+        generate(k - 1, arr)
+
+        for i in range(k - 1):
+            if k % 2 == 0:  # k is even
+                arr[i], arr[k - 1] = arr[k - 1], arr[i]
+            else:  # k is odd
+                arr[0], arr[k - 1] = arr[k - 1], arr[0]
+            generate(k - 1, arr)
+
+    generate(len(arr), arr)
+    return res
+
+
+if __name__ == "__main__":
+    user_input = input("Enter numbers separated by a comma:\n").strip()
+    arr = [int(item) for item in user_input.split(",")]
+    print(heaps(arr))

--- a/__tmp1/order_of_magnitude_conversion.rs
+++ b/__tmp1/order_of_magnitude_conversion.rs
@@ -1,0 +1,575 @@
+//! Length Unit Conversion
+//!
+//! This module provides conversion between metric length units ranging from
+//! meters to yottameters (10^24 meters).
+//!
+//! Available units: Meter, Kilometer, Megameter, Gigameter, Terameter,
+//! Petameter, Exameter, Zettameter, Yottameter
+//!
+//! ## Spelling Convention
+//!
+//! This module uses **American spellings** (meter, kilometer, etc.) for all
+//! official API elements including enum variants and documentation, following
+//! standard programming conventions and SI guidelines.
+//!
+//! However, the `FromStr` implementation **accepts both American and British spellings**
+//! for maximum compatibility:
+//! - American: "meter", "kilometer", "megameter", etc.
+//! - British: "metre", "kilometre", "megametre", etc.
+//!
+//! ```
+//! use the_algorithms_rust::conversions::MetricLengthUnit;
+//! use std::str::FromStr;
+//!
+//! // Both spellings work!
+//! let american: MetricLengthUnit = "megameter".parse().unwrap();
+//! let british: MetricLengthUnit = "megametre".parse().unwrap();
+//! assert_eq!(american, british); // Same enum variant
+//! ```
+//!
+//! # References
+//!
+//! - [Meter - Wikipedia](https://en.wikipedia.org/wiki/Meter)
+//! - [Kilometer - Wikipedia](https://en.wikipedia.org/wiki/Kilometer)
+//! - [Orders of Magnitude (Length) - Wikipedia](https://en.wikipedia.org/wiki/Orders_of_magnitude_(length))
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Represents different metric length units.
+///
+/// Each variant corresponds to a specific power of 10 relative to the base unit (meter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricLengthUnit {
+    /// Meter (m) - base unit, 10^0 meters
+    Meter,
+    /// Kilometer (km) - 10^3 meters
+    Kilometer,
+    /// Megameter (Mm) - 10^6 meters
+    Megameter,
+    /// Gigameter (Gm) - 10^9 meters
+    Gigameter,
+    /// Terameter (Tm) - 10^12 meters
+    Terameter,
+    /// Petameter (Pm) - 10^15 meters
+    Petameter,
+    /// Exameter (Em) - 10^18 meters
+    Exameter,
+    /// Zettameter (Zm) - 10^21 meters
+    Zettameter,
+    /// Yottameter (Ym) - 10^24 meters
+    Yottameter,
+}
+
+impl MetricLengthUnit {
+    /// Returns the exponent (power of 10) for this unit relative to meters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use the_algorithms_rust::conversions::MetricLengthUnit;
+    ///
+    /// assert_eq!(MetricLengthUnit::Meter.exponent(), 0);
+    /// assert_eq!(MetricLengthUnit::Kilometer.exponent(), 3);
+    /// assert_eq!(MetricLengthUnit::Megameter.exponent(), 6);
+    /// ```
+    pub fn exponent(&self) -> i32 {
+        match self {
+            MetricLengthUnit::Meter => 0,
+            MetricLengthUnit::Kilometer => 3,
+            MetricLengthUnit::Megameter => 6,
+            MetricLengthUnit::Gigameter => 9,
+            MetricLengthUnit::Terameter => 12,
+            MetricLengthUnit::Petameter => 15,
+            MetricLengthUnit::Exameter => 18,
+            MetricLengthUnit::Zettameter => 21,
+            MetricLengthUnit::Yottameter => 24,
+        }
+    }
+
+    /// Returns the standard abbreviation for this unit.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use the_algorithms_rust::conversions::MetricLengthUnit;
+    ///
+    /// assert_eq!(MetricLengthUnit::Meter.symbol(), "m");
+    /// assert_eq!(MetricLengthUnit::Kilometer.symbol(), "km");
+    /// ```
+    pub fn symbol(&self) -> &'static str {
+        match self {
+            MetricLengthUnit::Meter => "m",
+            MetricLengthUnit::Kilometer => "km",
+            MetricLengthUnit::Megameter => "Mm",
+            MetricLengthUnit::Gigameter => "Gm",
+            MetricLengthUnit::Terameter => "Tm",
+            MetricLengthUnit::Petameter => "Pm",
+            MetricLengthUnit::Exameter => "Em",
+            MetricLengthUnit::Zettameter => "Zm",
+            MetricLengthUnit::Yottameter => "Ym",
+        }
+    }
+}
+
+impl FromStr for MetricLengthUnit {
+    type Err = String;
+
+    /// Parses a unit from a string (case-insensitive, handles plurals).
+    ///
+    /// Accepts both full names (e.g., "meter", "meters") and symbols (e.g., "m", "km").
+    /// **Accepts both American and British spellings** (e.g., "megameter" and "megametre").
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use the_algorithms_rust::conversions::MetricLengthUnit;
+    /// use std::str::FromStr;
+    ///
+    /// // American spellings (official)
+    /// assert_eq!(MetricLengthUnit::from_str("meter").unwrap(), MetricLengthUnit::Meter);
+    /// assert_eq!(MetricLengthUnit::from_str("megameter").unwrap(), MetricLengthUnit::Megameter);
+    ///
+    /// // British spellings (also accepted)
+    /// assert_eq!(MetricLengthUnit::from_str("metre").unwrap(), MetricLengthUnit::Meter);
+    /// assert_eq!(MetricLengthUnit::from_str("megametre").unwrap(), MetricLengthUnit::Megameter);
+    ///
+    /// // Symbols and case-insensitive
+    /// assert_eq!(MetricLengthUnit::from_str("km").unwrap(), MetricLengthUnit::Kilometer);
+    /// assert_eq!(MetricLengthUnit::from_str("METERS").unwrap(), MetricLengthUnit::Meter);
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Sanitize: lowercase and remove trailing 's'
+        let sanitized = s.to_lowercase().trim_end_matches('s').to_string();
+
+        match sanitized.as_str() {
+            "meter" | "metre" | "m" => Ok(MetricLengthUnit::Meter),
+            "kilometer" | "kilometre" | "km" => Ok(MetricLengthUnit::Kilometer),
+            "megameter" | "megametre" | "mm" => Ok(MetricLengthUnit::Megameter),
+            "gigameter" | "gigametre" | "gm" => Ok(MetricLengthUnit::Gigameter),
+            "terameter" | "terametre" | "tm" => Ok(MetricLengthUnit::Terameter),
+            "petameter" | "petametre" | "pm" => Ok(MetricLengthUnit::Petameter),
+            "exameter" | "exametre" | "em" => Ok(MetricLengthUnit::Exameter),
+            "zettameter" | "zettametre" | "zm" => Ok(MetricLengthUnit::Zettameter),
+            "yottameter" | "yottametre" | "ym" => Ok(MetricLengthUnit::Yottameter),
+            _ => Err(format!(
+                "Invalid unit: '{s}'. Valid units are: m, km, Mm, Gm, Tm, Pm, Em, Zm, Ym"
+            )),
+        }
+    }
+}
+
+impl fmt::Display for MetricLengthUnit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.symbol())
+    }
+}
+
+/// Converts a length value from one unit to another.
+///
+/// # Arguments
+///
+/// * `value` - The numeric value to convert
+/// * `from` - The unit to convert from
+/// * `to` - The unit to convert to
+///
+/// # Returns
+///
+/// The converted value in the target unit
+///
+/// # Example
+///
+/// ```
+/// use the_algorithms_rust::conversions::{MetricLengthUnit, convert_metric_length};
+///
+/// let result = convert_metric_length(1.0, MetricLengthUnit::Meter, MetricLengthUnit::Kilometer);
+/// assert_eq!(result, 0.001);
+///
+/// let result = convert_metric_length(1.0, MetricLengthUnit::Kilometer, MetricLengthUnit::Meter);
+/// assert_eq!(result, 1000.0);
+/// ```
+pub fn convert_metric_length(value: f64, from: MetricLengthUnit, to: MetricLengthUnit) -> f64 {
+    let from_exp = from.exponent();
+    let to_exp = to.exponent();
+    let exponent = from_exp - to_exp;
+
+    value * 10_f64.powi(exponent)
+}
+
+/// Converts a length value from one unit to another using string unit names.
+///
+/// This function accepts both full unit names and abbreviations, and is case-insensitive.
+/// It also handles plural forms (e.g., "meters" and "meter" both work).
+///
+/// # Arguments
+///
+/// * `value` - The numeric value to convert
+/// * `from_type` - The unit to convert from (as a string)
+/// * `to_type` - The unit to convert to (as a string)
+///
+/// # Returns
+///
+/// `Ok(f64)` with the converted value, or `Err(String)` if either unit is invalid
+///
+/// # Example
+///
+/// ```
+/// use the_algorithms_rust::conversions::metric_length_conversion;
+///
+/// let result = metric_length_conversion(1.0, "meter", "kilometer").unwrap();
+/// assert_eq!(result, 0.001);
+///
+/// let result = metric_length_conversion(1.0, "km", "m").unwrap();
+/// assert_eq!(result, 1000.0);
+///
+/// // Case insensitive and handles plurals
+/// let result = metric_length_conversion(5.0, "METERS", "kilometers").unwrap();
+/// assert_eq!(result, 0.005);
+///
+/// // Invalid unit returns error
+/// assert!(metric_length_conversion(1.0, "wrongUnit", "meter").is_err());
+/// ```
+pub fn metric_length_conversion(value: f64, from_type: &str, to_type: &str) -> Result<f64, String> {
+    let from_unit = MetricLengthUnit::from_str(from_type).map_err(|_| {
+        format!(
+            "Invalid 'from_type' value: '{from_type}'.\nConversion abbreviations are: m, km, Mm, Gm, Tm, Pm, Em, Zm, Ym"
+        )
+    })?;
+
+    let to_unit = MetricLengthUnit::from_str(to_type).map_err(|_| {
+        format!(
+            "Invalid 'to_type' value: '{to_type}'.\nConversion abbreviations are: m, km, Mm, Gm, Tm, Pm, Em, Zm, Ym"
+        )
+    })?;
+
+    Ok(convert_metric_length(value, from_unit, to_unit))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unit_exponents() {
+        assert_eq!(MetricLengthUnit::Meter.exponent(), 0);
+        assert_eq!(MetricLengthUnit::Kilometer.exponent(), 3);
+        assert_eq!(MetricLengthUnit::Megameter.exponent(), 6);
+        assert_eq!(MetricLengthUnit::Gigameter.exponent(), 9);
+        assert_eq!(MetricLengthUnit::Terameter.exponent(), 12);
+        assert_eq!(MetricLengthUnit::Petameter.exponent(), 15);
+        assert_eq!(MetricLengthUnit::Exameter.exponent(), 18);
+        assert_eq!(MetricLengthUnit::Zettameter.exponent(), 21);
+        assert_eq!(MetricLengthUnit::Yottameter.exponent(), 24);
+    }
+
+    #[test]
+    fn test_unit_symbols() {
+        assert_eq!(MetricLengthUnit::Meter.symbol(), "m");
+        assert_eq!(MetricLengthUnit::Kilometer.symbol(), "km");
+        assert_eq!(MetricLengthUnit::Megameter.symbol(), "Mm");
+        assert_eq!(MetricLengthUnit::Gigameter.symbol(), "Gm");
+        assert_eq!(MetricLengthUnit::Terameter.symbol(), "Tm");
+        assert_eq!(MetricLengthUnit::Petameter.symbol(), "Pm");
+        assert_eq!(MetricLengthUnit::Exameter.symbol(), "Em");
+        assert_eq!(MetricLengthUnit::Zettameter.symbol(), "Zm");
+        assert_eq!(MetricLengthUnit::Yottameter.symbol(), "Ym");
+    }
+
+    #[test]
+    fn test_from_str_full_names() {
+        assert_eq!(
+            MetricLengthUnit::from_str("meter").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("kilometer").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("megameter").unwrap(),
+            MetricLengthUnit::Megameter
+        );
+    }
+
+    #[test]
+    fn test_from_str_symbols() {
+        assert_eq!(
+            MetricLengthUnit::from_str("m").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("km").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("Mm").unwrap(),
+            MetricLengthUnit::Megameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("Gm").unwrap(),
+            MetricLengthUnit::Gigameter
+        );
+    }
+
+    #[test]
+    fn test_from_str_case_insensitive() {
+        assert_eq!(
+            MetricLengthUnit::from_str("METER").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("KiLoMeTeR").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("KM").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+    }
+
+    #[test]
+    fn test_from_str_plurals() {
+        assert_eq!(
+            MetricLengthUnit::from_str("meters").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("kilometers").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+    }
+
+    #[test]
+    fn test_from_str_british_spellings() {
+        // Test that British spellings work (uses 're' instead of 'er')
+        assert_eq!(
+            MetricLengthUnit::from_str("metre").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("kilometre").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("megametre").unwrap(),
+            MetricLengthUnit::Megameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("gigametre").unwrap(),
+            MetricLengthUnit::Gigameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("terametre").unwrap(),
+            MetricLengthUnit::Terameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("petametre").unwrap(),
+            MetricLengthUnit::Petameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("exametre").unwrap(),
+            MetricLengthUnit::Exameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("zettametre").unwrap(),
+            MetricLengthUnit::Zettameter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("yottametre").unwrap(),
+            MetricLengthUnit::Yottameter
+        );
+
+        // British spellings with plurals
+        assert_eq!(
+            MetricLengthUnit::from_str("metres").unwrap(),
+            MetricLengthUnit::Meter
+        );
+        assert_eq!(
+            MetricLengthUnit::from_str("kilometres").unwrap(),
+            MetricLengthUnit::Kilometer
+        );
+    }
+
+    #[test]
+    fn test_from_str_american_and_british_equivalent() {
+        // Verify American and British spellings parse to the same enum variant
+        let american = MetricLengthUnit::from_str("megameter").unwrap();
+        let british = MetricLengthUnit::from_str("megametre").unwrap();
+        assert_eq!(american, british);
+        assert_eq!(american, MetricLengthUnit::Megameter);
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        assert!(MetricLengthUnit::from_str("wrongUnit").is_err());
+        assert!(MetricLengthUnit::from_str("inch").is_err());
+        assert!(MetricLengthUnit::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_convert_length_meter_to_kilometer() {
+        let result =
+            convert_metric_length(1.0, MetricLengthUnit::Meter, MetricLengthUnit::Kilometer);
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_convert_length_meter_to_megameter() {
+        let result =
+            convert_metric_length(1.0, MetricLengthUnit::Meter, MetricLengthUnit::Megameter);
+        assert_eq!(result, 1e-6);
+    }
+
+    #[test]
+    fn test_convert_length_gigameter_to_meter() {
+        let result =
+            convert_metric_length(1.0, MetricLengthUnit::Gigameter, MetricLengthUnit::Meter);
+        assert_eq!(result, 1_000_000_000.0);
+    }
+
+    #[test]
+    fn test_convert_length_gigameter_to_terameter() {
+        let result = convert_metric_length(
+            1.0,
+            MetricLengthUnit::Gigameter,
+            MetricLengthUnit::Terameter,
+        );
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_convert_length_petameter_to_terameter() {
+        let result = convert_metric_length(
+            1.0,
+            MetricLengthUnit::Petameter,
+            MetricLengthUnit::Terameter,
+        );
+        assert_eq!(result, 1000.0);
+    }
+
+    #[test]
+    fn test_convert_length_petameter_to_exameter() {
+        let result =
+            convert_metric_length(1.0, MetricLengthUnit::Petameter, MetricLengthUnit::Exameter);
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_convert_length_terameter_to_zettameter() {
+        let result = convert_metric_length(
+            1.0,
+            MetricLengthUnit::Terameter,
+            MetricLengthUnit::Zettameter,
+        );
+        assert_eq!(result, 1e-9);
+    }
+
+    #[test]
+    fn test_convert_length_yottameter_to_zettameter() {
+        let result = convert_metric_length(
+            1.0,
+            MetricLengthUnit::Yottameter,
+            MetricLengthUnit::Zettameter,
+        );
+        assert_eq!(result, 1000.0);
+    }
+
+    #[test]
+    fn test_convert_length_same_unit() {
+        let result = convert_metric_length(
+            42.0,
+            MetricLengthUnit::Kilometer,
+            MetricLengthUnit::Kilometer,
+        );
+        assert_eq!(result, 42.0);
+    }
+
+    #[test]
+    fn test_length_conversion_str_basic() {
+        let result = metric_length_conversion(1.0, "meter", "kilometer").unwrap();
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_length_conversion_str_symbols() {
+        let result = metric_length_conversion(1.0, "m", "km").unwrap();
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_length_conversion_str_case_insensitive() {
+        let result = metric_length_conversion(1.0, "METER", "KILOMETER").unwrap();
+        assert_eq!(result, 0.001);
+    }
+
+    #[test]
+    fn test_length_conversion_str_plurals() {
+        let result = metric_length_conversion(5.0, "meters", "kilometers").unwrap();
+        assert_eq!(result, 0.005);
+    }
+
+    #[test]
+    fn test_length_conversion_str_british_spellings() {
+        // Test that British spellings work in string-based API
+        let result = metric_length_conversion(1.0, "metre", "kilometre").unwrap();
+        assert_eq!(result, 0.001);
+
+        let result = metric_length_conversion(1000.0, "kilometre", "metre").unwrap();
+        assert_eq!(result, 1_000_000.0);
+
+        let result = metric_length_conversion(1.0, "gigametre", "megametre").unwrap();
+        assert_eq!(result, 1000.0);
+
+        // Mix American and British
+        let result = metric_length_conversion(1.0, "meter", "kilometre").unwrap();
+        assert_eq!(result, 0.001);
+
+        let result = metric_length_conversion(1.0, "megametre", "meter").unwrap();
+        assert_eq!(result, 1_000_000.0);
+    }
+
+    #[test]
+    fn test_length_conversion_str_invalid_from() {
+        let result = metric_length_conversion(1.0, "wrongUnit", "meter");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid 'from_type'"));
+    }
+
+    #[test]
+    fn test_length_conversion_str_invalid_to() {
+        let result = metric_length_conversion(1.0, "meter", "inch");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid 'to_type'"));
+    }
+
+    #[test]
+    fn test_length_conversion_str_large_values() {
+        let result = metric_length_conversion(1000.0, "km", "m").unwrap();
+        assert_eq!(result, 1_000_000.0);
+    }
+
+    #[test]
+    fn test_length_conversion_str_small_values() {
+        let result = metric_length_conversion(0.001, "m", "km").unwrap();
+        assert_eq!(result, 0.000001);
+    }
+
+    #[test]
+    fn test_all_conversions_reversible() {
+        let units = [
+            MetricLengthUnit::Meter,
+            MetricLengthUnit::Kilometer,
+            MetricLengthUnit::Megameter,
+            MetricLengthUnit::Gigameter,
+            MetricLengthUnit::Terameter,
+        ];
+
+        for &from in &units {
+            for &to in &units {
+                let forward = convert_metric_length(100.0, from, to);
+                let backward = convert_metric_length(forward, to, from);
+                assert!((backward - 100.0).abs() < 1e-9, "Conversion not reversible");
+            }
+        }
+    }
+}


### PR DESCRIPTION
14 Rejected the feature request for Excel-to-VCF conversion as it is outside the current scope of this project. Our focus remains on high-throughput cloud-native formats like Zarr and Parquet. Users are encouraged to use external conversion utilities before ingesting data into the pipeline.