### PR TITLE
Closes #48 Mark wontfix: Proprietary genomics format support

### DIFF
--- a/__proto6/GaleShapleyTest.java
+++ b/__proto6/GaleShapleyTest.java
@@ -1,0 +1,72 @@
+package com.thealgorithms.greedyalgorithms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class GaleShapleyTest {
+
+    @Test
+    public void testStableMatch() {
+        Map<String, LinkedList<String>> womenPrefs = new HashMap<>();
+        womenPrefs.put("A", new LinkedList<>(List.of("X", "Y", "Z")));
+        womenPrefs.put("B", new LinkedList<>(List.of("Y", "X", "Z")));
+        womenPrefs.put("C", new LinkedList<>(List.of("X", "Y", "Z")));
+
+        Map<String, LinkedList<String>> menPrefs = new HashMap<>();
+        menPrefs.put("X", new LinkedList<>(List.of("A", "B", "C")));
+        menPrefs.put("Y", new LinkedList<>(List.of("B", "A", "C")));
+        menPrefs.put("Z", new LinkedList<>(List.of("A", "B", "C")));
+
+        Map<String, String> result = GaleShapley.stableMatch(womenPrefs, menPrefs);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("A", "X");
+        expected.put("B", "Y");
+        expected.put("C", "Z");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testSinglePair() {
+        Map<String, LinkedList<String>> womenPrefs = new HashMap<>();
+        womenPrefs.put("A", new LinkedList<>(List.of("X")));
+
+        Map<String, LinkedList<String>> menPrefs = new HashMap<>();
+        menPrefs.put("X", new LinkedList<>(List.of("A")));
+
+        Map<String, String> result = GaleShapley.stableMatch(womenPrefs, menPrefs);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("A", "X");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testEqualPreferences() {
+        Map<String, LinkedList<String>> womenPrefs = new HashMap<>();
+        womenPrefs.put("A", new LinkedList<>(List.of("X", "Y", "Z")));
+        womenPrefs.put("B", new LinkedList<>(List.of("X", "Y", "Z")));
+        womenPrefs.put("C", new LinkedList<>(List.of("X", "Y", "Z")));
+
+        Map<String, LinkedList<String>> menPrefs = new HashMap<>();
+        menPrefs.put("X", new LinkedList<>(List.of("A", "B", "C")));
+        menPrefs.put("Y", new LinkedList<>(List.of("A", "B", "C")));
+        menPrefs.put("Z", new LinkedList<>(List.of("A", "B", "C")));
+
+        Map<String, String> result = GaleShapley.stableMatch(womenPrefs, menPrefs);
+
+        Map<String, String> expected = new HashMap<>();
+        expected.put("A", "X");
+        expected.put("B", "Y");
+        expected.put("C", "Z");
+
+        assertEquals(expected, result);
+    }
+}

--- a/__proto6/LFUCache.test.js
+++ b/__proto6/LFUCache.test.js
@@ -1,0 +1,77 @@
+import LFUCache from '../LFUCache'
+import { fibonacciCache } from './cacheTest'
+
+describe('Testing LFUCache class', () => {
+  it('Example 1 (Small Cache, size = 2)', () => {
+    const cache = new LFUCache(1) // initially capacity 1
+
+    cache.capacity = 2 // increase the capacity
+
+    expect(cache.capacity).toBe(2)
+
+    cache.set(1, 1) // frequency = 1
+    cache.set(2, 2) // frequency = 1
+
+    expect(cache.get(1)).toBe(1) // frequency = 2
+    expect(cache.get(2)).toBe(2) // frequency = 2
+
+    // Additional entries triggers cache rotate
+    cache.set(3, 3) // frequency = 1 & key 1 removed from the cached, cause now it's tie and followed the LRU system
+
+    expect(cache.get(1)).toBe(null) // misses = 1
+    expect(cache.get(2)).toBe(2) // frequency = 3
+    expect(cache.get(3)).toBe(3) // frequency = 2
+
+    cache.set(4, 4) // frequency = 1 & key 3 removed cause the frequency of 3 is 2 which is least frequency
+    expect(cache.get(1)).toBe(null) // misses = 2
+    expect(cache.get(2)).toBe(2) // frequency = 4
+    expect(cache.get(3)).toBe(null) // misses = 3
+    expect(cache.get(4)).toBe(4) // frequency = 2 which is least
+
+    expect(cache.info).toEqual({
+      misses: 3,
+      hits: 6,
+      capacity: 2,
+      currentSize: 2,
+      leastFrequency: 2
+    })
+
+    const json =
+      '{"misses":3,"hits":6,"cache":{"2":{"key":"2","value":2,"frequency":4},"4":{"key":"4","value":4,"frequency":2}}}'
+    expect(cache.toString()).toBe(json)
+
+    const cacheInstance = cache.parse(json) // again merge the json
+
+    expect(cacheInstance).toBe(cache) // return the same cache
+
+    cache.capacity = 1 // decrease the capacity
+
+    expect(cache.info).toEqual({
+      // after merging the info
+      misses: 6,
+      hits: 12,
+      capacity: 1,
+      currentSize: 1,
+      leastFrequency: 5
+    })
+
+    const clearedCache = cache.clear() // clear the cache
+    expect(clearedCache.size).toBe(0)
+  })
+
+  it('Example 2 (Computing Fibonacci Series, size = 100)', () => {
+    const cache = new LFUCache(100)
+
+    for (let i = 1; i <= 100; i++) {
+      fibonacciCache(i, cache)
+    }
+
+    expect(cache.info).toEqual({
+      misses: 103,
+      hits: 193,
+      capacity: 100,
+      currentSize: 98,
+      leastFrequency: 1
+    })
+  })
+})

--- a/__proto6/PrimMatrixTests.cs
+++ b/__proto6/PrimMatrixTests.cs
@@ -1,0 +1,390 @@
+using Algorithms.Graph.MinimumSpanningTree;
+
+namespace Algorithms.Tests.Graph.MinimumSpanningTree;
+
+internal class PrimTests
+{
+    [Test]
+    public void ValidateMatrix_WrongSize_ThrowsException()
+    {
+        // Wrong number of columns
+        var matrix = new[,]
+        {
+            { 0, 3, 4, float.PositiveInfinity },
+            { 3, 0, 5, 6 },
+            { 4, 5, 0, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, 0 },
+            { float.PositiveInfinity, 2, float.PositiveInfinity, float.PositiveInfinity },
+        };
+        Assert.Throws<ArgumentException>(() => PrimMatrix.Solve(matrix, 0));
+
+        // Wrong number of rows
+        matrix = new[,]
+        {
+            { 0, 3, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 0, 5, 6, 2 },
+            { 4, 5, 0, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, 0, float.PositiveInfinity },
+        };
+        Assert.Throws<ArgumentException>(() => PrimMatrix.Solve(matrix, 0));
+    }
+
+    [Test]
+    public void ValidateMatrix_UnconnectedGraph_ThrowsException()
+    {
+        // Last node does not connect to any other nodes
+        var matrix = new[,]
+        {
+            { 0, 3, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 0, 5, 6, 2 },
+            { 4, 5, 0, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, 0, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 0 },
+        };
+        Assert.Throws<ArgumentException>(() => PrimMatrix.Solve(matrix, 0));
+    }
+
+    [Test]
+    public void ValidateMatrix_DirectedGraph_ThrowsException()
+    {
+        // Nodes 1 and 2 have a directed edge
+        var matrix = new[,]
+        {
+            { 0, float.PositiveInfinity, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 0, 5, 6, 2 },
+            { 4, 5, 0, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, 0, float.PositiveInfinity },
+            { float.PositiveInfinity, 2, float.PositiveInfinity, float.PositiveInfinity, 0 },
+        };
+        Assert.Throws<ArgumentException>(() => PrimMatrix.Solve(matrix, 0));
+    }
+
+    [Test]
+    public void SolveMatrix_Graph1_CorrectAnswer()
+    {
+        /* Graph
+         *       (1)
+         *       / \
+         *      3   2
+         *     /     \
+         *   (0)--2--(2)
+         */
+        var matrix = new float[,]
+        {
+            { 0, 3, 2 },
+            { 3, 0, 2 },
+            { 2, 2, 0 },
+        };
+
+        /* Expected MST
+         *      (1)
+         *        \ 
+         *         2
+         *          \
+         *  (0)--2--(2)
+         */
+        var expected = new[,]
+        {
+            { float.PositiveInfinity, float.PositiveInfinity, 2 },
+            { float.PositiveInfinity, float.PositiveInfinity, 2 },
+            { 2, 2, float.PositiveInfinity },
+        };
+
+        for (var i = 0; i < matrix.GetLength(0); i++)
+        {
+            PrimMatrix.Solve(matrix, i).Cast<float>().SequenceEqual(expected.Cast<float>()).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void SolveMatrix_Graph2_CorrectAnswer()
+    {
+        /* Graph
+         *  (0)     (4)
+         *   |\     /
+         *   | 3   2
+         *   |  \ /
+         *   4  (1)
+         *   |  / \
+         *   | 5   6
+         *   |/     \
+         *  (2)     (3)
+         */
+        var matrix = new[,]
+        {
+            { 0, 3, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 0, 5, 6, 2 },
+            { 4, 5, 0, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, 0, float.PositiveInfinity },
+            { float.PositiveInfinity, 2, float.PositiveInfinity, float.PositiveInfinity, 0 },
+        };
+
+        /* Expected MST
+         *  (0)     (4)
+         *   |\     /
+         *   | 3   2
+         *   |  \ /
+         *   4  (1)
+         *   |    \
+         *   |     6
+         *   |      \
+         *  (2)     (3)
+         */
+        var expected = new[,]
+        {
+            { float.PositiveInfinity, 3, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, float.PositiveInfinity, float.PositiveInfinity, 6, 2 },
+            { 4, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 6, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 2, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+        };
+
+        for (var i = 0; i < matrix.GetLength(0); i++)
+        {
+            PrimMatrix.Solve(matrix, i).Cast<float>().SequenceEqual(expected.Cast<float>()).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void SolveMatrix_Graph3_CorrectAnswer()
+    {
+        /* Graph
+         *  (0)--3--(2)     (4)--2--(5)
+         *    \     / \     /
+         *     4   1   4   6
+         *      \ /     \ /
+         *      (1)--2--(3)
+         */
+        var matrix = new[,]
+        {
+            { 0, 4, 3, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { 4, 0, 1, 2, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 1, 0, 4, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 2, 4, 0, 6, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, 0, 2 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 2, 0 },
+        };
+
+        /* Graph
+         *  (0)--3--(2)     (4)--2--(5)
+         *          /       /
+         *         1       6
+         *        /       /
+         *      (1)--2--(3)
+         */
+        var expected = new[,]
+        {
+            { float.PositiveInfinity, float.PositiveInfinity, 3, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, 1, 2, float.PositiveInfinity, float.PositiveInfinity },
+            { 3, 1, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 2, float.PositiveInfinity, float.PositiveInfinity, 6, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, float.PositiveInfinity, 2 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 2, float.PositiveInfinity },
+        };
+
+        for (var i = 0; i < matrix.GetLength(0); i++)
+        {
+            PrimMatrix.Solve(matrix, i).Cast<float>().SequenceEqual(expected.Cast<float>()).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void SolveMatrix_Graph4_CorrectAnswer()
+    {
+        /* Graph
+         *  (0)--7--(1)--8--(2)
+         *    \     / \     /
+         *     5   9   7   5
+         *      \ /     \ /
+         *      (3)--15-(4)
+         *        \     / \
+         *         6   8   9
+         *          \ /     \
+         *          (5)--11-(6)
+         */
+        var matrix = new[,]
+        {
+            { 0, 7, float.PositiveInfinity, 5, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { 7, 0, 8, 9, 7, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 8, 0, float.PositiveInfinity, 5, float.PositiveInfinity, float.PositiveInfinity },
+            { 5, 9, float.PositiveInfinity, 0, 15, 6, float.PositiveInfinity },
+            { float.PositiveInfinity, 7, 5, 15, 0, 8, 9 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, 8, 0, 11 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 9, 11, 0 },
+        };
+
+        /* Expected MST
+         *  (0)--7--(1)     (2)
+         *    \       \     /
+         *     5       7   5
+         *      \       \ /
+         *      (3)     (4)
+         *        \       \
+         *         6       9
+         *          \       \
+         *          (5)     (6)
+         */
+        var expected = new[,]
+        {
+            { float.PositiveInfinity, 7, float.PositiveInfinity, 5, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { 7, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 7, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 5, float.PositiveInfinity, float.PositiveInfinity },
+            { 5, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, float.PositiveInfinity },
+            { float.PositiveInfinity, 7, 5, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 9 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 9, float.PositiveInfinity, float.PositiveInfinity },
+        };
+
+        for (var i = 0; i < matrix.GetLength(0); i++)
+        {
+            PrimMatrix.Solve(matrix, i).Cast<float>().SequenceEqual(expected.Cast<float>()).Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void SolveMatrix_Graph5_CorrectAnswer()
+    {
+        /* Graph
+         *  (0)--8--(1)--15-(2)
+         *   |\     /     __/|\
+         *   | 4   5  __25  13 12 
+         *   |  \ /__/       |   \
+         *  10  (3)----14---(4)  (5)
+         *   |  / \        _/|   /
+         *   | 9   6   __16  18 30
+         *   |/     \ /      |/
+         *  (6)--18-(7)--20-(8)
+         */
+        var matrix = new[,]
+        {
+            { 0, 8, float.PositiveInfinity, 4, float.PositiveInfinity, float.PositiveInfinity, 10, float.PositiveInfinity, float.PositiveInfinity },
+            { 8, 0, 15, 5, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { float.PositiveInfinity, 15, 0, 25, 13, 12, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity },
+            { 4, 5, 25, 0, 14, float.PositiveInfinity, 9, 6, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, 13, 14, 0, float.PositiveInfinity, float.PositiveInfinity, 16, 18 },
+            { float.PositiveInfinity, float.PositiveInfinity, 12, float.PositiveInfinity, float.PositiveInfinity, 0, float.PositiveInfinity, float.PositiveInfinity, 30 },
+            { 10, float.PositiveInfinity, float.PositiveInfinity, 9, float.PositiveInfinity, float.PositiveInfinity, 0, 18, float.PositiveInfinity },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 6, 16, float.PositiveInfinity, 18, 0, 20 },
+            { float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, float.PositiveInfinity, 18, 30, float.PositiveInfinity, 20, 0 },
+        };
+
+        /* Expected MST
+         *  (0)     (1)     (2)
+         *    \     /        |\
+         *     4   5        13 12 
+         *      \ /          |   \
+         *      (3)----14---(4)  (5)
+         *      / \          |
+         *     9   6         18
+         *    /     \        |
+         *  (6)     (7)     (8)
+         */
+        var expected = new[,]
+        {
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                4,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                5,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                13,
+                12,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                4,
+                5,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                14,
+                float.PositiveInfinity,
+                9,
+                6,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                13,
+                14,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                18,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                12,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                9,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                6,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+            {
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                18,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+                float.PositiveInfinity,
+            },
+        };
+
+        for (var i = 0; i < matrix.GetLength(0); i++)
+        {
+            PrimMatrix.Solve(matrix, i).Cast<float>().SequenceEqual(expected.Cast<float>()).Should().BeTrue();
+        }
+    }
+}

--- a/__proto6/heapsort.go
+++ b/__proto6/heapsort.go
@@ -1,0 +1,143 @@
+// heapsort.go
+// description: Implementation of heap sort algorithm
+// worst-case time complexity: O(n log n)
+// average-case time complexity: O(n log n)
+// space complexity: O(1)
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+type MaxHeap struct {
+	slice    []Comparable
+	heapSize int
+	indices  map[int]int
+}
+
+func (h *MaxHeap) Init(slice []Comparable) {
+	if slice == nil {
+		slice = make([]Comparable, 0)
+	}
+
+	h.slice = slice
+	h.heapSize = len(slice)
+	h.indices = make(map[int]int)
+	h.Heapify()
+}
+
+func (h MaxHeap) Heapify() {
+	for i, v := range h.slice {
+		h.indices[v.Idx()] = i
+	}
+	for i := h.heapSize / 2; i >= 0; i-- {
+		h.heapifyDown(i)
+	}
+}
+
+func (h *MaxHeap) Pop() Comparable {
+	if h.heapSize == 0 {
+		return nil
+	}
+
+	i := h.slice[0]
+	h.heapSize--
+
+	h.slice[0] = h.slice[h.heapSize]
+	h.updateidx(0)
+	h.heapifyDown(0)
+
+	h.slice = h.slice[0:h.heapSize]
+	return i
+}
+
+func (h *MaxHeap) Push(i Comparable) {
+	h.slice = append(h.slice, i)
+	h.updateidx(h.heapSize)
+	h.heapifyUp(h.heapSize)
+	h.heapSize++
+}
+
+func (h MaxHeap) Size() int {
+	return h.heapSize
+}
+
+func (h MaxHeap) Update(i Comparable) {
+	h.slice[h.indices[i.Idx()]] = i
+	h.heapifyUp(h.indices[i.Idx()])
+	h.heapifyDown(h.indices[i.Idx()])
+}
+
+func (h MaxHeap) updateidx(i int) {
+	h.indices[h.slice[i].Idx()] = i
+}
+
+func (h *MaxHeap) swap(i, j int) {
+	h.slice[i], h.slice[j] = h.slice[j], h.slice[i]
+	h.updateidx(i)
+	h.updateidx(j)
+}
+
+func (h MaxHeap) more(i, j int) bool {
+	return h.slice[i].More(h.slice[j])
+}
+
+func (h MaxHeap) heapifyUp(i int) {
+	if i == 0 {
+		return
+	}
+	p := i / 2
+
+	if h.slice[i].More(h.slice[p]) {
+		h.swap(i, p)
+		h.heapifyUp(p)
+	}
+}
+
+func (h MaxHeap) heapifyDown(i int) {
+	heapifyDown(h.slice, h.heapSize, i, h.more, h.swap)
+}
+
+func heapifyDown[T any](slice []T, N, i int, moreFunc func(i, j int) bool, swapFunc func(i, j int)) {
+	l, r := 2*i+1, 2*i+2
+	max := i
+
+	if l < N && moreFunc(l, max) {
+		max = l
+	}
+	if r < N && moreFunc(r, max) {
+		max = r
+	}
+	if max != i {
+		swapFunc(i, max)
+
+		heapifyDown(slice, N, max, moreFunc, swapFunc)
+	}
+}
+
+type Comparable interface {
+	Idx() int
+	More(any) bool
+}
+
+func HeapSort[T constraints.Ordered](slice []T) []T {
+	N := len(slice)
+
+	moreFunc := func(i, j int) bool {
+		return slice[i] > slice[j]
+	}
+	swapFunc := func(i, j int) {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+
+	// build a maxheap
+	for i := N/2 - 1; i >= 0; i-- {
+		heapifyDown(slice, N, i, moreFunc, swapFunc)
+	}
+
+	for i := N - 1; i > 0; i-- {
+		slice[i], slice[0] = slice[0], slice[i]
+		heapifyDown(slice, i, 0, moreFunc, swapFunc)
+	}
+
+	return slice
+}

--- a/__proto6/number_of_digits.test.ts
+++ b/__proto6/number_of_digits.test.ts
@@ -1,0 +1,22 @@
+import { numberOfDigits } from '../number_of_digits'
+
+describe('numberOfDigits', () => {
+  test.each([-890, -5.56, -7, 0, 0.73, 4.2, NaN, -Infinity, Infinity])(
+    'should throw an error for non natural number %d',
+    (num) => {
+      expect(() => numberOfDigits(num)).toThrowError(
+        'only natural numbers are supported'
+      )
+    }
+  )
+
+  test.each([
+    [1, 1],
+    [18, 2],
+    [549, 3],
+    [7293, 4],
+    [1234567890, 10]
+  ])('of %i should be %i', (num, expected) => {
+    expect(numberOfDigits(num)).toBe(expected)
+  })
+})

--- a/__proto6/statistics.jl
+++ b/__proto6/statistics.jl
@@ -1,0 +1,28 @@
+using TheAlgorithms.StatAlgo
+
+@testset "Statistics" begin
+    @testset "Statistics: Pearson Correlation" begin
+        a = 1:10
+        b = 1:10
+        @test pearson_correlation(a, b) == 1
+
+        x = [12, 15, 17, 21, 18]
+        y = [6, 9, -1, 3, 1]
+
+        @test pearson_correlation(x, y) == -0.5201361507569889
+    end
+
+    @testset "Statistics: Variance" begin
+        a = 1:10
+
+        @test variance(a) == 9.166666666666666
+
+        a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+        @test variance(a) == 9.166666666666666
+
+        a = [12, 15, 17, 20]
+
+        @test variance(a) == 11.333333333333334
+    end
+end


### PR DESCRIPTION
48 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.