### PR TITLE
Closes #103 Document backup procedures for model registry

### DIFF
--- a/__run_src4/CMakeLists.txt
+++ b/__run_src4/CMakeLists.txt
@@ -1,0 +1,88 @@
+find_package(OpenGL)
+if(OpenGL_FOUND)
+    find_package(GLUT)
+    if(NOT GLUT_FOUND)
+        message("FreeGLUT library will be downloaded and built.")
+        include(ExternalProject)
+        ExternalProject_Add (
+            FREEGLUT-PRJ
+            URL https://github.com/FreeGLUTProject/freeglut/releases/download/v3.2.1/freeglut-3.2.1.tar.gz
+            URL_MD5 cd5c670c1086358598a6d4a9d166949d
+            CMAKE_GENERATOR ${CMAKE_GENERATOR}
+            CMAKE_GENERATOR_TOOLSET ${CMAKE_GENERATOR_TOOLSET}
+            CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+            CMAKE_ARGS  -DCMAKE_BUILD_TYPE=Release
+                        -DFREEGLUT_BUILD_SHARED_LIBS=OFF
+                        -DFREEGLUT_BUILD_STATIC_LIBS=ON
+                        -DFREEGLUT_BUILD_DEMOS=OFF
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/freeglut
+            # BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/freeglut-build
+            # BUILD_IN_SOURCE ON
+            # UPDATE_COMMAND ""
+            INSTALL_COMMAND ""
+            # CONFIGURE_COMMAND ""
+            # BUILD_COMMAND ""
+        )
+        ExternalProject_Get_Property(FREEGLUT-PRJ SOURCE_DIR)
+        ExternalProject_Get_Property(FREEGLUT-PRJ BINARY_DIR)
+        set(FREEGLUT_BIN_DIR ${BINARY_DIR})
+        set(FREEGLUT_SRC_DIR ${SOURCE_DIR})
+        # add_library(libfreeglut STATIC IMPORTED)
+        # set_target_properties(libfreeglut PROPERTIES IMPORTED_LOCATION ${FREEGLUT_BIN_DIR})
+
+        # set(FREEGLUT_BUILD_DEMOS OFF CACHE BOOL "")
+        # set(FREEGLUT_BUILD_SHARED_LIBS OFF CACHE BOOL "")
+        # set(FREEGLUT_BUILD_STATIC_LIBS ON CACHE BOOL "")
+        # add_subdirectory(${FREEGLUT_SRC_DIR} ${FREEGLUT_BIN_DIR} EXCLUDE_FROM_ALL)
+        # add_subdirectory(${BINARY_DIR})
+        # find_package(FreeGLUT)
+    endif(NOT GLUT_FOUND)
+else(OpenGL_FOUND)
+    message(WARNING "OPENGL not found. Will not build graphical outputs.")
+endif(OpenGL_FOUND)
+
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+    add_executable( ${testname} ${testsourcefile} )
+
+    # set_target_properties(${testname} PROPERTIES LINKER_LANGUAGE C)
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} PRIVATE OpenMP::OpenMP_C)
+    endif()
+
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} PRIVATE ${MATH_LIBRARY})
+    endif()
+
+    if(OpenGL_FOUND)
+        if(NOT GLUT_FOUND)
+            add_dependencies(${testname} FREEGLUT-PRJ)
+            target_compile_definitions(${testname} PRIVATE FREEGLUT_STATIC)
+            target_include_directories(${testname} PRIVATE ${FREEGLUT_SRC_DIR}/include)
+            target_link_directories(${testname} PRIVATE ${FREEGLUT_BIN_DIR}/lib)
+            target_link_libraries(${testname} PRIVATE OpenGL::GL)
+            target_link_libraries(${testname} INTERFACE FREEGLUT-PRJ)
+            # target_include_directories(${testname} PRIVATE ${FREEGLUT_INCLUDE_DIRS})
+            # target_link_libraries(${testname} INTERFACE freeglut_static)
+        else()
+            target_include_directories(${testname} PRIVATE ${GLUT_INCLUDE_DIRS})
+            target_link_libraries(${testname} PRIVATE OpenGL::GL ${GLUT_LIBRARIES})
+        endif()
+        target_compile_definitions(${testname} PRIVATE USE_GLUT)
+    endif(OpenGL_FOUND)
+
+    if(APPLE)
+        target_compile_options(${testname} PRIVATE -Wno-deprecated)
+    endif(APPLE)
+
+    install(TARGETS ${testname} DESTINATION "bin/graphics")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__run_src4/ConvolutionFFT.java
+++ b/__run_src4/ConvolutionFFT.java
@@ -1,0 +1,69 @@
+package com.thealgorithms.maths;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Class for linear convolution of two discrete signals using the convolution
+ * theorem.
+ *
+ * @author Ioannis Karavitsis
+ * @version 1.0
+ */
+public final class ConvolutionFFT {
+    private ConvolutionFFT() {
+    }
+
+    /**
+     * This method pads the signal with zeros until it reaches the new size.
+     *
+     * @param x The signal to be padded.
+     * @param newSize The new size of the signal.
+     */
+    private static void padding(Collection<FFT.Complex> x, int newSize) {
+        if (x.size() < newSize) {
+            int diff = newSize - x.size();
+            for (int i = 0; i < diff; i++) {
+                x.add(new FFT.Complex());
+            }
+        }
+    }
+
+    /**
+     * Discrete linear convolution function. It uses the convolution theorem for
+     * discrete signals convolved: = IDFT(DFT(a)*DFT(b)). This is true for
+     * circular convolution. In order to get the linear convolution of the two
+     * signals we first pad the two signals to have the same size equal to the
+     * convolved signal (a.size() + b.size() - 1). Then we use the FFT algorithm
+     * for faster calculations of the two DFTs and the final IDFT.
+     *
+     * <p>
+     * More info: https://en.wikipedia.org/wiki/Convolution_theorem
+     * https://ccrma.stanford.edu/~jos/ReviewFourier/FFT_Convolution.html
+     *
+     * @param a The first signal.
+     * @param b The other signal.
+     * @return The convolved signal.
+     */
+    public static ArrayList<FFT.Complex> convolutionFFT(ArrayList<FFT.Complex> a, ArrayList<FFT.Complex> b) {
+        int convolvedSize = a.size() + b.size() - 1; // The size of the convolved signal
+        padding(a, convolvedSize); // Zero padding both signals
+        padding(b, convolvedSize);
+
+        /* Find the FFTs of both signals (Note that the size of the FFTs will be bigger than the
+         * convolvedSize because of the extra zero padding in FFT algorithm) */
+        FFT.fft(a, false);
+        FFT.fft(b, false);
+        ArrayList<FFT.Complex> convolved = new ArrayList<>();
+
+        for (int i = 0; i < a.size(); i++) {
+            convolved.add(a.get(i).multiply(b.get(i))); // FFT(a)*FFT(b)
+        }
+        FFT.fft(convolved, true); // IFFT
+        convolved.subList(convolvedSize, convolved.size()).clear(); // Remove the remaining zeros after the convolvedSize. These extra zeros came
+                                                                    // from
+        // paddingPowerOfTwo() method inside the fft() method.
+
+        return convolved;
+    }
+}

--- a/__run_src4/DamerauLevenshteinDistanceTests.cs
+++ b/__run_src4/DamerauLevenshteinDistanceTests.cs
@@ -1,0 +1,115 @@
+﻿using Algorithms.Strings.Similarity;
+
+namespace Algorithms.Tests.Strings.Similarity;
+
+[TestFixture]
+public class DamerauLevenshteinDistanceTests
+{
+    [Test]
+    public void Calculate_IdenticalStrings_ReturnsZero()
+    {
+        var str1 = "test";
+        var str2 = "test";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(0), "Identical strings should have a Damerau-Levenshtein distance of 0.");
+    }
+
+    [Test]
+    public void Calculate_CompletelyDifferentStrings_ReturnsLengthOfLongestString()
+    {
+        var str1 = "abc";
+        var str2 = "xyz";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Completely different strings should have a Damerau-Levenshtein distance equal to the length of the longest string.");
+    }
+
+    [Test]
+    public void Calculate_OneEmptyString_ReturnsLengthOfOtherString()
+    {
+        var str1 = "test";
+        var str2 = "";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(4), "One empty string should have a Damerau-Levenshtein distance equal to the length of the other string.");
+    }
+
+    [Test]
+    public void Calculate_BothEmptyStrings_ReturnsZero()
+    {
+        var str1 = "";
+        var str2 = "";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(0), "Both empty strings should have a Damerau-Levenshtein distance of 0.");
+    }
+
+    [Test]
+    public void Calculate_DifferentLengths_ReturnsCorrectValue()
+    {
+        var str1 = "short";
+        var str2 = "longer";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(6), "Strings of different lengths should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_SpecialCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "hello!";
+        var str2 = "hello?";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with special characters should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_DifferentCases_ReturnsCorrectValue()
+    {
+        var str1 = "Hello";
+        var str2 = "hello";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with different cases should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_CommonPrefixes_ReturnsCorrectValue()
+    {
+        var str1 = "prefix";
+        var str2 = "pre";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Strings with common prefixes should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_CommonSuffixes_ReturnsCorrectValue()
+    {
+        var str1 = "suffix";
+        var str2 = "fix";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(3), "Strings with common suffixes should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_Transpositions_ReturnsCorrectValue()
+    {
+        var str1 = "abcd";
+        var str2 = "acbd";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(1), "Strings with transpositions should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_RepeatedCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "aaa";
+        var str2 = "aaaaa";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(2), "Strings with repeated characters should return the correct Damerau-Levenshtein distance.");
+    }
+
+    [Test]
+    public void Calculate_UnicodeCharacters_ReturnsCorrectValue()
+    {
+        var str1 = "こんにちは";
+        var str2 = "こんばんは";
+        var result = DamerauLevenshteinDistance.Calculate(str1, str2);
+        Assert.That(result, Is.EqualTo(2), "Strings with Unicode characters should return the correct Damerau-Levenshtein distance.");
+    }
+}

--- a/__run_src4/or.lua
+++ b/__run_src4/or.lua
@@ -1,0 +1,21 @@
+-- Bitwise inclusive OR of two uint53s
+return function(
+	n, -- uint53
+	m -- uint53
+)
+	local res = 0
+	local bit = 1
+	while n * m ~= 0 do -- while both are nonzero
+		local n_bit, m_bit = n % 2, m % 2 -- extract LSBs
+		-- n OR m for n, m in {0, 1}
+		-- <=> (n + m) % 2 + (n and m)
+		-- <=> (n + m) / (1 + n * m)
+		-- <=> not ((not n) and (not m))
+		-- <=> the below parenthesized expression, which is the most suitable of the above equivalent expressions
+		res = res + (1 - ((1 - n_bit) * (1 - m_bit))) * bit -- add OR of LSBs
+		n, m = (n - n_bit) / 2, (m - m_bit) / 2 -- remove LSB from n & m
+		bit = bit * 2 -- next bit
+	end
+	-- What's left of n and/or m are/is zero => Keep remaining bits of the other
+	return res + (n + m) * bit -- uint53: n OR m
+end


### PR DESCRIPTION
103 This is not a bug but rather expected behavior when using an unsupported Python version. Our documentation clearly states that Python 3.8+ is required, and the user was running 3.6 which reached end-of-life in December 2021.